### PR TITLE
More container support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `GenericArray014` container type to support `generic-array=0.14`. ([#3])
+- `BorrowedSliceLike` container type. ([#3])
 
 
 [#3]: https://github.com/fjarri/serde-encoded-bytes/pull/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed proxy traits `TryFromSliceRef` and `TryFromArray`. ([#3])
 
 
+### Added
+
+- `GenericArray014` container type to support `generic-array=0.14`. ([#3])
+
+
 [#3]: https://github.com/fjarri/serde-encoded-bytes/pull/3
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.0] - Under development
+
+### Changed
+
+- Removed proxy traits `TryFromSliceRef` and `TryFromArray`. ([#3])
+
+
+[#3]: https://github.com/fjarri/serde-encoded-bytes/pull/3
+
+
 ## [0.1.1] - 2025-01-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.70.0"
 serde = { version = "1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }
+generic-array-014 = { package = "generic-array", version = "0.14", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1", default-features = false, features = ["derive"] }
@@ -31,6 +32,8 @@ serde_asn1_der = "0.8"
 # (since we need some encoding to be present in the API).
 # Should be removed when https://github.com/rust-lang/cargo/issues/2911 is fixed.
 default = ["hex"]
+
+generic-array-014 = ["dep:generic-array-014"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use serde::{Deserializer, Serializer};
 
 use crate::encoding::Encoding;
-use crate::low_level::{self, TryFromArray, TryFromSliceRef};
+use crate::low_level;
 
 /// A container for array-like data, e.g. Rust stack arrays, or `generic_array::GenericArray<...>`.
 ///
@@ -18,7 +18,7 @@ use crate::low_level::{self, TryFromArray, TryFromSliceRef};
 ///
 /// Requirements:
 /// - serializer requires the field to implement `AsRef<[u8]>`;
-/// - deserializer requires the field to implement [`TryFromArray`] or `TryFrom<[u8; N]>`.
+/// - deserializer requires the field to implement `TryFrom<[u8; N]>`.
 pub struct ArrayLike<Enc: Encoding>(PhantomData<Enc>);
 
 impl<Enc: Encoding> ArrayLike<Enc> {
@@ -35,7 +35,7 @@ impl<Enc: Encoding> ArrayLike<Enc> {
     pub fn deserialize<'de, T, E, D, const N: usize>(deserializer: D) -> Result<T, D::Error>
     where
         D: Deserializer<'de>,
-        T: TryFromArray<E, N>,
+        T: TryFrom<[u8; N], Error = E>,
         E: fmt::Display,
     {
         low_level::deserialize_array::<Enc, N, _, _, _>(deserializer)
@@ -48,7 +48,7 @@ impl<Enc: Encoding> ArrayLike<Enc> {
 ///
 /// Requirements:
 /// - serializer requires the field to implement `AsRef<[u8]>`;
-/// - deserializer requires the field to implement [`TryFromSliceRef`] or `TryFrom<&[u8]>`.
+/// - deserializer requires the field to implement `TryFrom<&[u8]>`.
 pub struct SliceLike<Enc: Encoding>(PhantomData<Enc>);
 
 impl<Enc: Encoding> SliceLike<Enc> {
@@ -65,7 +65,7 @@ impl<Enc: Encoding> SliceLike<Enc> {
     pub fn deserialize<'de, T, E, D>(deserializer: D) -> Result<T, D::Error>
     where
         D: Deserializer<'de>,
-        T: for<'a> TryFromSliceRef<'a, E>,
+        T: for<'a> TryFrom<&'a [u8], Error = E>,
         E: fmt::Display,
     {
         low_level::deserialize_slice::<Enc, _, _, _>(deserializer)
@@ -96,7 +96,7 @@ impl<Enc: Encoding> BoxedArrayLike<Enc> {
     pub fn deserialize<'de, T, E, D, const N: usize>(deserializer: D) -> Result<T, D::Error>
     where
         D: Deserializer<'de>,
-        T: TryFromArray<E, N>,
+        T: TryFrom<[u8; N], Error = E>,
         E: fmt::Display,
     {
         low_level::deserialize_array::<Enc, N, _, _, _>(deserializer)

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -7,7 +7,10 @@ use serde::{Deserializer, Serializer};
 use crate::encoding::Encoding;
 use crate::low_level;
 
-/// A container for array-like data, e.g. Rust stack arrays, or `generic_array::GenericArray<...>`.
+/// A container for array-like data, e.g. Rust stack arrays.
+///
+/// For a `GenericArray` from `generic-array=0.14` with the size parametrized
+/// by a generic parameter, use [`GenericArray014`].
 ///
 /// For use in the `#[serde(with)]` field attribute.
 ///
@@ -100,6 +103,44 @@ impl<Enc: Encoding> BoxedArrayLike<Enc> {
         E: fmt::Display,
     {
         low_level::deserialize_array::<Enc, N, _, _, _>(deserializer)
+    }
+}
+
+/// A container for `generic_array::GenericArray<...>` from `generic-array=0.14`
+/// (either with a fixed size or generic).
+///
+/// For use in the `#[serde(with)]` field attribute.
+///
+/// Note that the length of the array will be serialized as well;
+/// this is caused by `serde` not being able to communicate to format implementations
+/// that the array has a constant size.
+/// See <https://github.com/serde-rs/serde/issues/2120> for details.
+#[cfg(feature = "generic-array-014")]
+pub struct GenericArray014<Enc: Encoding>(PhantomData<Enc>);
+
+#[cfg(feature = "generic-array-014")]
+impl<Enc: Encoding> GenericArray014<Enc> {
+    /// Serializes array-like data.
+    pub fn serialize<L, S>(
+        obj: &generic_array_014::GenericArray<u8, L>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        L: generic_array_014::ArrayLength<u8>,
+        S: Serializer,
+    {
+        low_level::serialize_slice::<Enc, _>(obj.as_ref(), serializer)
+    }
+
+    /// Deserializes into array-like data.
+    pub fn deserialize<'de, L, D>(
+        deserializer: D,
+    ) -> Result<generic_array_014::GenericArray<u8, L>, D::Error>
+    where
+        D: Deserializer<'de>,
+        L: generic_array_014::ArrayLength<u8>,
+    {
+        low_level::deserialize_generic_array_014::<Enc, L, _>(deserializer)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ mod tests;
 pub use containers::{ArrayLike, BoxedArrayLike, SliceLike};
 pub use encoding::Encoding;
 
+#[cfg(feature = "generic-array-014")]
+pub use containers::GenericArray014;
+
 // Specifically enable `Hex` for tests, since we need some encoding to be specified.
 // Should be removed when https://github.com/rust-lang/cargo/issues/2911 is fixed.
 #[cfg(any(feature = "hex", test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ mod tests;
 
 pub use containers::{ArrayLike, BoxedArrayLike, SliceLike};
 pub use encoding::Encoding;
-pub use low_level::{TryFromArray, TryFromSliceRef};
 
 // Specifically enable `Hex` for tests, since we need some encoding to be specified.
 // Should be removed when https://github.com/rust-lang/cargo/issues/2911 is fixed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod low_level;
 #[cfg(test)]
 mod tests;
 
-pub use containers::{ArrayLike, BoxedArrayLike, SliceLike};
+pub use containers::{ArrayLike, BorrowedSliceLike, BoxedArrayLike, SliceLike};
 pub use encoding::Encoding;
 
 #[cfg(feature = "generic-array-014")]

--- a/src/low_level.rs
+++ b/src/low_level.rs
@@ -59,6 +59,51 @@ where
     }
 }
 
+struct BorrowedSliceVisitor<Enc, T, E>(PhantomData<(Enc, T, E)>);
+
+impl<Enc, T, E> de::Visitor<'_> for BorrowedSliceVisitor<Enc, T, E>
+where
+    Enc: Encoding,
+    T: Clone,
+    for<'a> &'a T: TryFrom<&'a [u8], Error = E>,
+    E: fmt::Display,
+{
+    type Value = T;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "a bytestring")
+    }
+
+    fn visit_str<SE>(self, v: &str) -> Result<Self::Value, SE>
+    where
+        SE: de::Error,
+    {
+        let bytes = Enc::decode(v)?;
+        let bytes_len = bytes.len();
+        let result_ref: &T = AsRef::<[u8]>::as_ref(&bytes).try_into().map_err(|err| {
+            de::Error::custom(format!(
+                "Failed to instantiate `{}` from a byte slice of length {bytes_len}: {err}",
+                type_name::<T>()
+            ))
+        })?;
+        Ok(result_ref.clone())
+    }
+
+    fn visit_bytes<SE>(self, v: &[u8]) -> Result<Self::Value, SE>
+    where
+        SE: de::Error,
+    {
+        let v_len = v.len();
+        let result_ref: &T = v.try_into().map_err(|err| {
+            de::Error::custom(format!(
+                "Failed to instantiate `{}` from a byte slice of length {v_len}: {err}",
+                type_name::<T>()
+            ))
+        })?;
+        Ok(result_ref.clone())
+    }
+}
+
 struct ArrayVisitor<Enc, T, E, const N: usize>(PhantomData<(Enc, T, E)>);
 
 impl<Enc, T, E, const N: usize> de::Visitor<'_> for ArrayVisitor<Enc, T, E, N>
@@ -165,6 +210,22 @@ where
     }
 }
 
+pub(crate) fn deserialize_borrowed_slice<'de, Enc: Encoding, T, E, D>(
+    deserializer: D,
+) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Clone,
+    for<'a> &'a T: TryFrom<&'a [u8], Error = E>,
+    E: fmt::Display,
+{
+    if deserializer.is_human_readable() {
+        deserializer.deserialize_str(BorrowedSliceVisitor::<Enc, T, E>(PhantomData))
+    } else {
+        deserializer.deserialize_bytes(BorrowedSliceVisitor::<Enc, T, E>(PhantomData))
+    }
+}
+
 pub(crate) fn deserialize_array<'de, Enc: Encoding, const N: usize, T, E, D>(
     deserializer: D,
 ) -> Result<T, D::Error>
@@ -205,7 +266,7 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{encoding::Hex, ArrayLike, SliceLike};
+    use crate::{encoding::Hex, ArrayLike, BorrowedSliceLike, SliceLike};
 
     #[cfg(feature = "generic-array-014")]
     use crate::GenericArray014;
@@ -215,6 +276,9 @@ mod tests {
 
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct VectorStruct(#[serde(with = "SliceLike::<Hex>")] Vec<u8>);
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct BorrowStruct<const N: usize>(#[serde(with = "BorrowedSliceLike::<Hex>")] Borrow<N>);
 
     #[cfg(feature = "generic-array-014")]
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -228,7 +292,28 @@ mod tests {
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct WrongValue(u32);
 
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Borrow<const N: usize>([u8; N]);
+
+    impl<const N: usize> AsRef<[u8]> for Borrow<N> {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_ref()
+        }
+    }
+
+    impl<'a, const N: usize> TryFrom<&'a [u8]> for &'a Borrow<N> {
+        type Error = String;
+        fn try_from(source: &'a [u8]) -> Result<Self, Self::Error> {
+            let source_len = source.len();
+            if source_len != N {
+                return Err(format!("The slice must have length {N}"));
+            }
+
+            Ok(unsafe { &*(source.as_ptr() as *const Borrow<N>) })
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
     struct BadType([u8; 4]);
 
     impl AsRef<[u8]> for BadType {
@@ -254,11 +339,24 @@ mod tests {
         }
     }
 
+    impl<'a> TryFrom<&'a [u8]> for &'a BadType {
+        type Error = String;
+        fn try_from(source: &'a [u8]) -> Result<Self, Self::Error> {
+            let source_len = source.len();
+            Err(format!(
+                "BadType cannot deserialize from `&[u8]` of length {source_len}"
+            ))
+        }
+    }
+
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct BadArrayStruct(#[serde(with = "ArrayLike::<Hex>")] BadType);
 
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct BadSliceStruct(#[serde(with = "SliceLike::<Hex>")] BadType);
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct BadBorrowSliceStruct(#[serde(with = "BorrowedSliceLike::<Hex>")] BadType);
 
     fn bin_serialize<T: Serialize>(value: T) -> Result<Vec<u8>, String> {
         rmp_serde::encode::to_vec(&value).map_err(|err| err.to_string())
@@ -401,6 +499,67 @@ mod tests {
         let bad_struct_bytes = bin_serialize(BadSliceStruct(BadType([1, 2, 3, 4]))).unwrap();
         assert_eq!(
             bin_deserialize::<BadSliceStruct>(&bad_struct_bytes).unwrap_err(),
+            concat![
+                "Failed to instantiate `serde_encoded_bytes::low_level::tests::BadType` ",
+                "from a byte slice of length 4: ",
+                "BadType cannot deserialize from `&[u8]` of length 4"
+            ]
+        );
+    }
+
+    #[test]
+    fn borrow_slice_visitor_human_readable() {
+        let val = BorrowStruct(Borrow([1, 2, 3, 4]));
+
+        // Normal operation
+        let val_str = hr_serialize(&val).unwrap();
+        let val_back = hr_deserialize::<BorrowStruct<4>>(&val_str).unwrap();
+        assert_eq!(val, val_back);
+
+        // Failed to decode
+        assert_eq!(
+            hr_deserialize::<BorrowStruct<4>>("\"0x0102030\"").unwrap_err(),
+            "Odd number of digits at line 1 column 11"
+        );
+
+        // Unexpected value type
+        assert_eq!(
+            hr_deserialize::<BorrowStruct<4>>("1").unwrap_err(),
+            "invalid type: integer `1`, expected a bytestring at line 1 column 1"
+        );
+
+        // A struct that always fails on deserialization
+        let bad_struct_str = hr_serialize(BadBorrowSliceStruct(BadType([1, 2, 3, 4]))).unwrap();
+        assert_eq!(
+            hr_deserialize::<BadBorrowSliceStruct>(&bad_struct_str).unwrap_err(),
+            concat![
+                "Failed to instantiate `serde_encoded_bytes::low_level::tests::BadType` ",
+                "from a byte slice of length 4: ",
+                "BadType cannot deserialize from `&[u8]` of length 4 at line 1 column 12"
+            ]
+        );
+    }
+
+    #[test]
+    fn borrow_slice_visitor_binary() {
+        let val = BorrowStruct(Borrow([1, 2, 3, 4]));
+
+        // Normal operation
+        let val_bytes = bin_serialize(&val).unwrap();
+        let val_back = bin_deserialize::<BorrowStruct<4>>(&val_bytes).unwrap();
+        assert_eq!(val, val_back);
+
+        // Unexpected value type
+        let wrong_val_bytes = bin_serialize(WrongValue(0x01020304)).unwrap();
+        assert_eq!(
+            bin_deserialize::<BorrowStruct<4>>(&wrong_val_bytes).unwrap_err(),
+            "invalid type: integer `16909060`, expected a bytestring"
+        );
+
+        // A struct that always fails on deserialization
+        let bad_struct_bytes = bin_serialize(BadBorrowSliceStruct(BadType([1, 2, 3, 4]))).unwrap();
+        assert_eq!(
+            bin_deserialize::<BadBorrowSliceStruct>(&bad_struct_bytes).unwrap_err(),
             concat![
                 "Failed to instantiate `serde_encoded_bytes::low_level::tests::BadType` ",
                 "from a byte slice of length 4: ",

--- a/src/tests/asn1.rs
+++ b/src/tests/asn1.rs
@@ -40,7 +40,7 @@ fn roundtrip_array() {
     let val_bigger_bytes = asn1_serialize(val_bigger).unwrap();
     assert_eq!(
         asn1_deserialize::<TestArray>(&val_bigger_bytes).unwrap_err(),
-        "Serde error: Expected byte array of length 16, got 17"
+        "Serde error: Expected a bytestring of length 16, got 17"
     );
 
     let val_smaller = SmallerTestArray {
@@ -49,7 +49,7 @@ fn roundtrip_array() {
     let val_smaller_bytes = asn1_serialize(val_smaller).unwrap();
     assert_eq!(
         asn1_deserialize::<TestArray>(&val_smaller_bytes).unwrap_err(),
-        "Serde error: Expected byte array of length 16, got 15"
+        "Serde error: Expected a bytestring of length 16, got 15"
     );
 }
 

--- a/src/tests/bincode.rs
+++ b/src/tests/bincode.rs
@@ -41,7 +41,7 @@ fn roundtrip_array() {
     let val_bigger_bytes = bincode_serialize(val_bigger).unwrap();
     assert_eq!(
         bincode_deserialize::<TestArray>(&val_bigger_bytes).unwrap_err(),
-        "OtherString(\"Expected byte array of length 16, got 17\")"
+        "OtherString(\"Expected a bytestring of length 16, got 17\")"
     );
 
     let val_smaller = SmallerTestArray {
@@ -50,7 +50,7 @@ fn roundtrip_array() {
     let val_smaller_bytes = bincode_serialize(val_smaller).unwrap();
     assert_eq!(
         bincode_deserialize::<TestArray>(&val_smaller_bytes).unwrap_err(),
-        "OtherString(\"Expected byte array of length 16, got 15\")"
+        "OtherString(\"Expected a bytestring of length 16, got 15\")"
     );
 }
 

--- a/src/tests/cbor.rs
+++ b/src/tests/cbor.rs
@@ -52,7 +52,7 @@ fn roundtrip_array() {
     let val_bigger_bytes = cbor_serialize(val_bigger).unwrap();
     assert_eq!(
         cbor_deserialize::<TestArray>(&val_bigger_bytes).unwrap_err(),
-        "Semantic(None, \"Expected byte array of length 16, got 17\")"
+        "Semantic(None, \"Expected a bytestring of length 16, got 17\")"
     );
 
     let val_smaller = SmallerTestArray {
@@ -61,7 +61,7 @@ fn roundtrip_array() {
     let val_smaller_bytes = cbor_serialize(val_smaller).unwrap();
     assert_eq!(
         cbor_deserialize::<TestArray>(&val_smaller_bytes).unwrap_err(),
-        "Semantic(None, \"Expected byte array of length 16, got 15\")"
+        "Semantic(None, \"Expected a bytestring of length 16, got 15\")"
     );
 }
 

--- a/src/tests/messagepack.rs
+++ b/src/tests/messagepack.rs
@@ -40,7 +40,7 @@ fn roundtrip_array() {
     let val_bigger_bytes = messagepack_serialize(val_bigger).unwrap();
     assert_eq!(
         messagepack_deserialize::<TestArray>(&val_bigger_bytes).unwrap_err(),
-        "Expected byte array of length 16, got 17"
+        "Expected a bytestring of length 16, got 17"
     );
 
     let val_smaller = SmallerTestArray {
@@ -49,7 +49,7 @@ fn roundtrip_array() {
     let val_smaller_bytes = messagepack_serialize(val_smaller).unwrap();
     assert_eq!(
         messagepack_deserialize::<TestArray>(&val_smaller_bytes).unwrap_err(),
-        "Expected byte array of length 16, got 15"
+        "Expected a bytestring of length 16, got 15"
     );
 }
 

--- a/src/tests/serde_json.rs
+++ b/src/tests/serde_json.rs
@@ -35,7 +35,7 @@ fn roundtrip_array() {
     let val_bigger_bytes = json_serialize(val_bigger).unwrap();
     assert_eq!(
         json_deserialize::<TestArray>(&val_bigger_bytes).unwrap_err(),
-        "Expected byte array of length 16, got 17 at line 1 column 47"
+        "Expected a bytestring of length 16, got 17 at line 1 column 47"
     );
 
     let val_smaller = SmallerTestArray {
@@ -44,7 +44,7 @@ fn roundtrip_array() {
     let val_smaller_bytes = json_serialize(val_smaller).unwrap();
     assert_eq!(
         json_deserialize::<TestArray>(&val_smaller_bytes).unwrap_err(),
-        "Expected byte array of length 16, got 15 at line 1 column 43"
+        "Expected a bytestring of length 16, got 15 at line 1 column 43"
     );
 }
 


### PR DESCRIPTION
- Remove the unneeded proxy traits `TryFromArray` and `TryFromSliceRef`
- Add more information in deserialization error messages
- Add special support for `GenericArray` from `generic-array=0.14` which is widely used in the currently stable RustCrypto stack crates (gated under `generic-array-014` feature)
- Add `GenericArray` v1 support (and other types that can borrow the bytes)
